### PR TITLE
feat: add feature flag tag endpoint

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,7 @@
     "healthz",
     "healthzhandler",
     "labstack",
+    "nolint",
     "organizationhandler",
     "organizationmodel",
     "signin",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,8 @@
 {
   "cSpell.words": [
-    "bson", 
+    "apierrors",
+    "apiutils",
+    "bson",
     "featureflaghandler",
     "featureflagmodel",
     "healthz",

--- a/pkg/api/error/error.go
+++ b/pkg/api/error/error.go
@@ -1,4 +1,4 @@
-package api_errors
+package apierrors
 
 import (
 	"net/http"

--- a/pkg/api/handlers/feature_flag_test.go
+++ b/pkg/api/handlers/feature_flag_test.go
@@ -140,6 +140,12 @@ func (suite *FeatureFlagHandlerTestSuite) TestPostFeatureFlagSuccess() {
 	assert.Equal(t, []string{"my_tag"}, response.Tags)
 	assert.Equal(t, featureFlagRequest.ProjectName, response.Project)
 
+	organizationModel := organizationmodel.New(suite.db)
+	updatedOrganization, err := organizationModel.FindByID(context.Background(), organization.ID)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, updatedOrganization.Tags)
+	assert.Equal(t, []string{"my_tag"}, updatedOrganization.Tags)
+
 	assert.NotEmpty(t, response.Revisions)
 	responseRevision := response.Revisions[0]
 	assert.Equal(t, user.ID, responseRevision.UserID)
@@ -1041,6 +1047,12 @@ func (suite *FeatureFlagHandlerTestSuite) TestPatchTagSuccess() {
 	assert.NoError(t, err)
 	assert.Equal(t, expected, updatedFlag.Tags)
 	assert.NotEqual(t, featureFlagRecord.UpdatedAt, updatedFlag.UpdatedAt)
+
+	organizationModel := organizationmodel.New(suite.db)
+	updatedOrganization, err := organizationModel.FindByID(context.Background(), organization.ID)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, updatedOrganization.Tags)
+	assert.Equal(t, expected, updatedOrganization.Tags)
 }
 
 func (suite *FeatureFlagHandlerTestSuite) TestPatchTagForbidden() {

--- a/pkg/api/handlers/fixtures/create_feature_flag.go
+++ b/pkg/api/handlers/fixtures/create_feature_flag.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/Roll-Play/togglelabs/pkg/models"
 	featureflagmodel "github.com/Roll-Play/togglelabs/pkg/models/feature_flag"
-	"github.com/Roll-Play/togglelabs/pkg/storage"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 )
@@ -21,12 +21,14 @@ func CreateFeatureFlag(
 	flagType featureflagmodel.FlagType,
 	revision []featureflagmodel.Revision,
 	environments []featureflagmodel.FeatureFlagEnvironment,
+	tags []string,
 	db *mongo.Database,
 ) *featureflagmodel.FeatureFlagRecord {
 	model := featureflagmodel.New(db)
 	if name == "" {
 		name = "feature"
 	}
+
 	if environments == nil {
 		environments = []featureflagmodel.FeatureFlagEnvironment{
 			{
@@ -35,11 +37,17 @@ func CreateFeatureFlag(
 			},
 		}
 	}
+
 	if revision == nil {
 		revision = []featureflagmodel.Revision{
 			*CreateRevision(userID, featureflagmodel.Draft, primitive.NilObjectID),
 		}
 	}
+
+	if tags == nil {
+		tags = []string{}
+	}
+
 	record := &featureflagmodel.FeatureFlagRecord{
 		OrganizationID: organizationID,
 		UserID:         userID,
@@ -47,7 +55,8 @@ func CreateFeatureFlag(
 		Name:           name,
 		Type:           flagType,
 		Revisions:      revision,
-		Timestamps: storage.Timestamps{
+		Tags:           tags,
+		Timestamps: models.Timestamps{
 			CreatedAt: primitive.NewDateTimeFromTime(time.Now().UTC()),
 			UpdatedAt: primitive.NewDateTimeFromTime(time.Now().UTC()),
 		},

--- a/pkg/api/handlers/fixtures/create_organization.go
+++ b/pkg/api/handlers/fixtures/create_organization.go
@@ -20,7 +20,7 @@ func CreateOrganization(
 	db *mongo.Database,
 ) *organizationmodel.OrganizationRecord {
 	organizationCounter++
-	members := make([]organizationmodel.OrganizationMember, 0)
+	members := make([]organizationmodel.OrganizationMember, 0, len(users))
 	if len(users) < 1 {
 		user := CreateUser("", "", "", "", db)
 		members = append(members, organizationmodel.OrganizationMember{

--- a/pkg/api/handlers/organization.go
+++ b/pkg/api/handlers/organization.go
@@ -5,10 +5,10 @@ import (
 	"errors"
 	"net/http"
 
-	api_errors "github.com/Roll-Play/togglelabs/pkg/api/error"
+	apierrors "github.com/Roll-Play/togglelabs/pkg/api/error"
 	organizationmodel "github.com/Roll-Play/togglelabs/pkg/models/organization"
 	usermodel "github.com/Roll-Play/togglelabs/pkg/models/user"
-	api_utils "github.com/Roll-Play/togglelabs/pkg/utils/api_utils"
+	apiutils "github.com/Roll-Play/togglelabs/pkg/utils/api_utils"
 	"github.com/go-playground/validator/v10"
 	"github.com/labstack/echo/v4"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -28,11 +28,11 @@ func (oh *OrganizationHandler) PostOrganization(c echo.Context) error {
 	request := new(OrganizationPostRequest)
 	if err := c.Bind(request); err != nil {
 		oh.logger.Debug("Client error",
-			zap.String("cause", err.Error()),
+			zap.Error(err),
 		)
-		return api_errors.CustomError(c,
+		return apierrors.CustomError(c,
 			http.StatusBadRequest,
-			api_errors.BadRequestError,
+			apierrors.BadRequestError,
 		)
 	}
 
@@ -40,34 +40,34 @@ func (oh *OrganizationHandler) PostOrganization(c echo.Context) error {
 
 	if err := validate.Struct(request); err != nil {
 		oh.logger.Debug("Client error",
-			zap.String("cause", err.Error()),
+			zap.Error(err),
 		)
-		return api_errors.CustomError(c,
+		return apierrors.CustomError(c,
 			http.StatusBadRequest,
-			api_errors.BadRequestError,
+			apierrors.BadRequestError,
 		)
 	}
 
-	userID, err := api_utils.GetUserFromContext(c)
+	userID, err := apiutils.GetUserFromContext(c)
 	if err != nil {
 		// Should never happen but better safe than sorry
-		if errors.Is(err, api_utils.ErrNotAuthenticated) {
+		if errors.Is(err, apiutils.ErrNotAuthenticated) {
 			oh.logger.Debug("Client error",
-				zap.String("cause", err.Error()),
+				zap.Error(err),
 			)
-			return api_errors.CustomError(
+			return apierrors.CustomError(
 				c,
 				http.StatusUnauthorized,
-				api_errors.UnauthorizedError,
+				apierrors.UnauthorizedError,
 			)
 		}
 
 		oh.logger.Debug("Server error",
-			zap.String("cause", err.Error()),
+			zap.Error(err),
 		)
-		return api_errors.CustomError(c,
+		return apierrors.CustomError(c,
 			http.StatusInternalServerError,
-			api_errors.InternalServerError,
+			apierrors.InternalServerError,
 		)
 	}
 
@@ -75,12 +75,12 @@ func (oh *OrganizationHandler) PostOrganization(c echo.Context) error {
 	user, err := userModel.FindByID(context.Background(), userID)
 	if err != nil {
 		oh.logger.Debug("Server error",
-			zap.String("cause", err.Error()),
+			zap.Error(err),
 		)
-		return api_errors.CustomError(
+		return apierrors.CustomError(
 			c,
 			http.StatusInternalServerError,
-			api_errors.InternalServerError,
+			apierrors.InternalServerError,
 		)
 	}
 
@@ -97,11 +97,11 @@ func (oh *OrganizationHandler) PostOrganization(c echo.Context) error {
 
 	if err != nil {
 		oh.logger.Debug("Server error",
-			zap.String("cause", err.Error()),
+			zap.Error(err),
 		)
-		return api_errors.CustomError(c,
+		return apierrors.CustomError(c,
 			http.StatusInternalServerError,
-			api_errors.InternalServerError,
+			apierrors.InternalServerError,
 		)
 	}
 

--- a/pkg/api/handlers/organization_test.go
+++ b/pkg/api/handlers/organization_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/Roll-Play/togglelabs/pkg/config"
 	"github.com/Roll-Play/togglelabs/pkg/logger"
 	organizationmodel "github.com/Roll-Play/togglelabs/pkg/models/organization"
-	api_utils "github.com/Roll-Play/togglelabs/pkg/utils/api_utils"
+	apiutils "github.com/Roll-Play/togglelabs/pkg/utils/api_utils"
 	testutils "github.com/Roll-Play/togglelabs/pkg/utils/test_utils"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
@@ -65,7 +65,7 @@ func (suite *OrganizationHandlerTestSuite) TestPostOrganizationHandlerSuccess() 
 	model := organizationmodel.New(suite.db)
 
 	user := fixtures.CreateUser("", "", "", "", suite.db)
-	token, err := api_utils.CreateJWT(user.ID, time.Second*120)
+	token, err := apiutils.CreateJWT(user.ID, time.Second*120)
 	assert.NoError(t, err)
 
 	requestBody := []byte(`{

--- a/pkg/api/handlers/sign_in.go
+++ b/pkg/api/handlers/sign_in.go
@@ -6,10 +6,10 @@ import (
 	"net/http"
 
 	"github.com/Roll-Play/togglelabs/pkg/api/common"
-	api_errors "github.com/Roll-Play/togglelabs/pkg/api/error"
+	apierrors "github.com/Roll-Play/togglelabs/pkg/api/error"
 	"github.com/Roll-Play/togglelabs/pkg/config"
 	usermodel "github.com/Roll-Play/togglelabs/pkg/models/user"
-	api_utils "github.com/Roll-Play/togglelabs/pkg/utils/api_utils"
+	apiutils "github.com/Roll-Play/togglelabs/pkg/utils/api_utils"
 	"github.com/go-playground/validator/v10"
 	"github.com/labstack/echo/v4"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -32,11 +32,11 @@ func (sh *SignInHandler) PostSignIn(c echo.Context) error {
 
 	if err := c.Bind(request); err != nil {
 		sh.logger.Debug("Client error",
-			zap.String("cause", err.Error()),
+			zap.Error(err),
 		)
-		return api_errors.CustomError(c,
+		return apierrors.CustomError(c,
 			http.StatusInternalServerError,
-			api_errors.InternalServerError,
+			apierrors.InternalServerError,
 		)
 	}
 
@@ -44,11 +44,11 @@ func (sh *SignInHandler) PostSignIn(c echo.Context) error {
 
 	if err := validate.Struct(request); err != nil {
 		sh.logger.Debug("Client error",
-			zap.String("cause", err.Error()),
+			zap.Error(err),
 		)
-		return api_errors.CustomError(c,
+		return apierrors.CustomError(c,
 			http.StatusBadRequest,
-			api_errors.BadRequestError,
+			apierrors.BadRequestError,
 		)
 	}
 
@@ -59,43 +59,43 @@ func (sh *SignInHandler) PostSignIn(c echo.Context) error {
 	if err != nil {
 		if errors.Is(err, mongo.ErrNoDocuments) {
 			sh.logger.Debug("Client error",
-				zap.String("cause", api_errors.NotFoundError),
+				zap.Error(errors.New(apierrors.NotFoundError)),
 			)
-			return api_errors.CustomError(c,
+			return apierrors.CustomError(c,
 				http.StatusNotFound,
-				api_errors.NotFoundError,
+				apierrors.NotFoundError,
 			)
 		}
 
 		sh.logger.Debug("Server error",
-			zap.String("cause", err.Error()),
+			zap.Error(err),
 		)
-		return api_errors.CustomError(
+		return apierrors.CustomError(
 			c,
 			http.StatusInternalServerError,
-			api_errors.InternalServerError,
+			apierrors.InternalServerError,
 		)
 	}
 
 	if err := bcrypt.CompareHashAndPassword([]byte(ur.Password), []byte(request.Password)); err != nil {
 		sh.logger.Debug("Client error",
-			zap.String("cause", err.Error()),
+			zap.Error(err),
 		)
-		return api_errors.CustomError(
+		return apierrors.CustomError(
 			c,
 			http.StatusUnauthorized,
-			api_errors.UnauthorizedError,
+			apierrors.UnauthorizedError,
 		)
 	}
 
-	token, err := api_utils.CreateJWT(ur.ID, config.JWTExpireTime)
+	token, err := apiutils.CreateJWT(ur.ID, config.JWTExpireTime)
 	if err != nil {
 		sh.logger.Debug("Server error",
-			zap.String("cause", err.Error()),
+			zap.Error(err),
 		)
-		return api_errors.CustomError(c,
+		return apierrors.CustomError(c,
 			http.StatusInternalServerError,
-			api_errors.InternalServerError,
+			apierrors.InternalServerError,
 		)
 	}
 

--- a/pkg/api/handlers/sign_in_test.go
+++ b/pkg/api/handlers/sign_in_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/Roll-Play/togglelabs/pkg/api/common"
-	api_errors "github.com/Roll-Play/togglelabs/pkg/api/error"
+	apierrors "github.com/Roll-Play/togglelabs/pkg/api/error"
 	"github.com/Roll-Play/togglelabs/pkg/api/handlers"
 	"github.com/Roll-Play/togglelabs/pkg/api/handlers/fixtures"
 	"github.com/Roll-Play/togglelabs/pkg/config"
@@ -92,13 +92,13 @@ func (suite *SignInHandlerTestSuite) TestSignInHandlerNotFound() {
 	recorder := httptest.NewRecorder()
 
 	suite.Server.ServeHTTP(recorder, request)
-	var response api_errors.Error
+	var response apierrors.Error
 
 	assert.Equal(t, http.StatusNotFound, recorder.Code)
 	assert.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
-	assert.Equal(t, api_errors.Error{
+	assert.Equal(t, apierrors.Error{
 		Error:   http.StatusText(http.StatusNotFound),
-		Message: api_errors.NotFoundError,
+		Message: apierrors.NotFoundError,
 	}, response)
 }
 
@@ -117,13 +117,13 @@ func (suite *SignInHandlerTestSuite) TestSignInHandlerUnauthorized() {
 	recorder := httptest.NewRecorder()
 
 	suite.Server.ServeHTTP(recorder, request)
-	var response api_errors.Error
+	var response apierrors.Error
 
 	assert.Equal(t, http.StatusUnauthorized, recorder.Code)
 	assert.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
-	assert.Equal(t, api_errors.Error{
+	assert.Equal(t, apierrors.Error{
 		Error:   http.StatusText(http.StatusUnauthorized),
-		Message: api_errors.UnauthorizedError,
+		Message: apierrors.UnauthorizedError,
 	}, response)
 }
 

--- a/pkg/api/handlers/sign_up_test.go
+++ b/pkg/api/handlers/sign_up_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/Roll-Play/togglelabs/pkg/api/common"
-	api_errors "github.com/Roll-Play/togglelabs/pkg/api/error"
+	apierrors "github.com/Roll-Play/togglelabs/pkg/api/error"
 	"github.com/Roll-Play/togglelabs/pkg/api/handlers"
 	"github.com/Roll-Play/togglelabs/pkg/api/handlers/fixtures"
 	"github.com/Roll-Play/togglelabs/pkg/config"
@@ -97,13 +97,13 @@ func (suite *SignUpHandlerTestSuite) TestSignUpHandlerUnsuccessful() {
 	recorder := httptest.NewRecorder()
 
 	suite.Server.ServeHTTP(recorder, request)
-	var response api_errors.Error
+	var response apierrors.Error
 
 	assert.Equal(t, http.StatusConflict, recorder.Code)
 	assert.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
-	assert.Equal(t, response, api_errors.Error{
+	assert.Equal(t, response, apierrors.Error{
 		Error:   http.StatusText(http.StatusConflict),
-		Message: api_errors.EmailConflictError,
+		Message: apierrors.EmailConflictError,
 	})
 }
 

--- a/pkg/api/handlers/sso.go
+++ b/pkg/api/handlers/sso.go
@@ -9,10 +9,10 @@ import (
 	"os"
 
 	"github.com/Roll-Play/togglelabs/pkg/api/common"
-	api_errors "github.com/Roll-Play/togglelabs/pkg/api/error"
+	apierrors "github.com/Roll-Play/togglelabs/pkg/api/error"
 	"github.com/Roll-Play/togglelabs/pkg/config"
 	usermodel "github.com/Roll-Play/togglelabs/pkg/models/user"
-	api_utils "github.com/Roll-Play/togglelabs/pkg/utils/api_utils"
+	apiutils "github.com/Roll-Play/togglelabs/pkg/utils/api_utils"
 	"github.com/labstack/echo/v4"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.uber.org/zap"
@@ -23,16 +23,16 @@ type SsoHandler struct {
 	oauthConfig *oauth2.Config
 	db          *mongo.Database
 	logger      *zap.Logger
-	httpClient  api_utils.BaseHTTPClient
-	oauthClient api_utils.OAuthClient
+	httpClient  apiutils.BaseHTTPClient
+	oauthClient apiutils.OAuthClient
 }
 
 func NewSsoHandler(
 	db *mongo.Database,
 	oauthConfig *oauth2.Config,
 	logger *zap.Logger,
-	httpClient api_utils.BaseHTTPClient,
-	oauthClient api_utils.OAuthClient,
+	httpClient apiutils.BaseHTTPClient,
+	oauthClient apiutils.OAuthClient,
 ) *SsoHandler {
 	return &SsoHandler{
 		oauthConfig: oauthConfig,
@@ -62,39 +62,39 @@ func (sh *SsoHandler) Callback(c echo.Context) error {
 
 	if err != nil {
 		sh.logger.Debug("Server error",
-			zap.String("cause", err.Error()),
+			zap.Error(err),
 		)
-		return api_errors.CustomError(
+		return apierrors.CustomError(
 			c,
 			http.StatusInternalServerError,
-			api_errors.InternalServerError,
+			apierrors.InternalServerError,
 		)
 	}
 	userData := new(usermodel.UserRecord)
 	err = json.Unmarshal(userDataBytes, userData)
 	if err != nil {
 		sh.logger.Debug("Server error",
-			zap.String("cause", err.Error()),
+			zap.Error(err),
 		)
-		return api_errors.CustomError(
+		return apierrors.CustomError(
 			c,
 			http.StatusInternalServerError,
-			api_errors.InternalServerError,
+			apierrors.InternalServerError,
 		)
 	}
 
 	model := usermodel.New(sh.db)
 	foundRecord, err := model.FindByEmail(context.Background(), userData.Email)
 	if err == nil {
-		token, err := api_utils.CreateJWT(foundRecord.ID, config.JWTExpireTime)
+		token, err := apiutils.CreateJWT(foundRecord.ID, config.JWTExpireTime)
 		if err != nil {
 			sh.logger.Debug("Server error",
-				zap.String("cause", err.Error()),
+				zap.Error(err),
 			)
-			return api_errors.CustomError(
+			return apierrors.CustomError(
 				c,
 				http.StatusInternalServerError,
-				api_errors.InternalServerError,
+				apierrors.InternalServerError,
 			)
 		}
 
@@ -110,24 +110,24 @@ func (sh *SsoHandler) Callback(c echo.Context) error {
 	objectID, err := model.InsertOne(context.Background(), userData)
 	if err != nil {
 		sh.logger.Debug("Server error",
-			zap.String("cause", err.Error()),
+			zap.Error(err),
 		)
-		return api_errors.CustomError(
+		return apierrors.CustomError(
 			c,
 			http.StatusInternalServerError,
-			api_errors.InternalServerError,
+			apierrors.InternalServerError,
 		)
 	}
 
-	token, err := api_utils.CreateJWT(objectID, config.JWTExpireTime)
+	token, err := apiutils.CreateJWT(objectID, config.JWTExpireTime)
 	if err != nil {
 		sh.logger.Debug("Server error",
-			zap.String("cause", err.Error()),
+			zap.Error(err),
 		)
-		return api_errors.CustomError(
+		return apierrors.CustomError(
 			c,
 			http.StatusInternalServerError,
-			api_errors.InternalServerError,
+			apierrors.InternalServerError,
 		)
 	}
 

--- a/pkg/api/handlers/user.go
+++ b/pkg/api/handlers/user.go
@@ -6,10 +6,9 @@ import (
 	"log"
 	"net/http"
 
-	api_errors "github.com/Roll-Play/togglelabs/pkg/api/error"
-	organizationmodel "github.com/Roll-Play/togglelabs/pkg/models/organization"
+	apierrors "github.com/Roll-Play/togglelabs/pkg/api/error"
 	usermodel "github.com/Roll-Play/togglelabs/pkg/models/user"
-	api_utils "github.com/Roll-Play/togglelabs/pkg/utils/api_utils"
+	apiutils "github.com/Roll-Play/togglelabs/pkg/utils/api_utils"
 	"github.com/go-playground/validator/v10"
 	"github.com/labstack/echo/v4"
 	"go.mongodb.org/mongo-driver/bson"
@@ -42,90 +41,47 @@ type UserPatchResponse struct {
 	LastName  string             `json:"last_name,omitempty" `
 }
 
-type UserOrganization struct {
-	ID   primitive.ObjectID `json:"_id"`
-	Name string             `json:"name"`
-}
-
-type UserGetResponse struct {
-	ID            primitive.ObjectID `json:"_id"`
-	Email         string             `json:"email"`
-	FirstName     string             `json:"first_name,omitempty"`
-	LastName      string             `json:"last_name,omitempty"`
-	Organizations []UserOrganization `json:"organizations"`
-}
-
-func NewUserGetResponse(user *usermodel.UserRecord, organizations []organizationmodel.OrganizationRecord) *UserGetResponse {
-	userOrganizations := make([]UserOrganization, len(organizations))
-
-	for index, organization := range organizations {
-		userOrganizations[index] = UserOrganization{
-			ID:   organization.ID,
-			Name: organization.Name,
-		}
-	}
-
-	return &UserGetResponse{
-		ID:            user.ID,
-		Email:         user.Email,
-		FirstName:     user.FirstName,
-		LastName:      user.LastName,
-		Organizations: userOrganizations,
-	}
-}
-
 func (uh *UserHandler) GetUser(c echo.Context) error {
-	userID, err := api_utils.GetUserFromContext(c)
+	userID, err := apiutils.GetUserFromContext(c)
 	if err != nil {
-		log.Println(api_utils.HandlerErrorLogMessage(err, c))
+		log.Println(apiutils.HandlerErrorLogMessage(err, c))
 		// Should never happen but better safe than sorry
-		if errors.Is(err, api_utils.ErrNotAuthenticated) {
+		if errors.Is(err, apiutils.ErrNotAuthenticated) {
 			uh.logger.Debug("Client error",
-				zap.String("cause", err.Error()),
+				zap.Error(err),
 			)
-			return api_errors.CustomError(
+			return apierrors.CustomError(
 				c,
 				http.StatusUnauthorized,
-				api_errors.UnauthorizedError,
+				apierrors.UnauthorizedError,
 			)
 		}
 
 		uh.logger.Debug("Server error",
-			zap.String("cause", err.Error()),
+			zap.Error(err),
 		)
-		return api_errors.CustomError(
+		return apierrors.CustomError(
 			c,
 			http.StatusInternalServerError,
-			api_errors.InternalServerError,
+			apierrors.InternalServerError,
 		)
 	}
 
 	model := usermodel.New(uh.db)
-	user, err := model.FindByID(context.Background(), userID)
+	user, err := model.FindUserOrganization(context.Background(), userID)
 	if err != nil {
 		uh.logger.Debug("Client error",
-			zap.String("cause", err.Error()),
+			zap.Error(err),
 		)
-		return api_errors.CustomError(c,
+		return apierrors.CustomError(c,
 			http.StatusNotFound,
-			api_errors.NotFoundError,
-		)
-	}
-
-	organizationModel := organizationmodel.New(uh.db)
-	organizations, err := organizationModel.FindByMember(context.Background(), user.ID)
-	if err != nil {
-		uh.logger.Debug("Server error",
-			zap.String("cause", err.Error()))
-		return api_errors.CustomError(c,
-			http.StatusInternalServerError,
-			api_errors.InternalServerError,
+			apierrors.NotFoundError,
 		)
 	}
 
 	return c.JSON(
 		http.StatusOK,
-		NewUserGetResponse(user, organizations),
+		user,
 	)
 }
 
@@ -133,11 +89,11 @@ func (uh *UserHandler) PatchUser(c echo.Context) error {
 	request := new(UserPatchRequest)
 	if err := c.Bind(request); err != nil {
 		uh.logger.Debug("Client error",
-			zap.String("cause", err.Error()),
+			zap.Error(err),
 		)
-		return api_errors.CustomError(c,
+		return apierrors.CustomError(c,
 			http.StatusBadRequest,
-			api_errors.BadRequestError,
+			apierrors.BadRequestError,
 		)
 	}
 
@@ -145,36 +101,36 @@ func (uh *UserHandler) PatchUser(c echo.Context) error {
 
 	if err := validate.Struct(request); err != nil {
 		uh.logger.Debug("Client error",
-			zap.String("cause", err.Error()),
+			zap.Error(err),
 		)
-		return api_errors.CustomError(c,
+		return apierrors.CustomError(c,
 			http.StatusBadRequest,
-			api_errors.BadRequestError,
+			apierrors.BadRequestError,
 		)
 	}
 
-	userID, err := api_utils.GetUserFromContext(c)
+	userID, err := apiutils.GetUserFromContext(c)
 	if err != nil {
-		log.Println(api_utils.HandlerErrorLogMessage(err, c))
+		log.Println(apiutils.HandlerErrorLogMessage(err, c))
 		// Should never happen but better safe than sorry
-		if errors.Is(err, api_utils.ErrNotAuthenticated) {
+		if errors.Is(err, apiutils.ErrNotAuthenticated) {
 			uh.logger.Debug("Client error",
-				zap.String("cause", err.Error()),
+				zap.Error(err),
 			)
-			return api_errors.CustomError(
+			return apierrors.CustomError(
 				c,
 				http.StatusUnauthorized,
-				api_errors.UnauthorizedError,
+				apierrors.UnauthorizedError,
 			)
 		}
 
 		uh.logger.Debug("Server error",
-			zap.String("cause", err.Error()),
+			zap.Error(err),
 		)
-		return api_errors.CustomError(
+		return apierrors.CustomError(
 			c,
 			http.StatusInternalServerError,
-			api_errors.InternalServerError,
+			apierrors.InternalServerError,
 		)
 	}
 
@@ -182,11 +138,11 @@ func (uh *UserHandler) PatchUser(c echo.Context) error {
 	ur, err := model.FindByID(context.Background(), userID)
 	if err != nil {
 		uh.logger.Debug("Client error",
-			zap.String("cause", err.Error()),
+			zap.Error(err),
 		)
-		return api_errors.CustomError(c,
+		return apierrors.CustomError(c,
 			http.StatusNotFound,
-			api_errors.NotFoundError,
+			apierrors.NotFoundError,
 		)
 	}
 
@@ -201,11 +157,11 @@ func (uh *UserHandler) PatchUser(c echo.Context) error {
 
 	if err != nil {
 		uh.logger.Debug("Server error",
-			zap.String("cause", err.Error()),
+			zap.Error(err),
 		)
-		return api_errors.CustomError(c,
+		return apierrors.CustomError(c,
 			http.StatusInternalServerError,
-			api_errors.InternalServerError,
+			apierrors.InternalServerError,
 		)
 	}
 

--- a/pkg/api/handlers/user_test.go
+++ b/pkg/api/handlers/user_test.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/Roll-Play/togglelabs/pkg/api/common"
-	api_errors "github.com/Roll-Play/togglelabs/pkg/api/error"
+	apierrors "github.com/Roll-Play/togglelabs/pkg/api/error"
 	"github.com/Roll-Play/togglelabs/pkg/api/handlers"
 	"github.com/Roll-Play/togglelabs/pkg/api/handlers/fixtures"
 	"github.com/Roll-Play/togglelabs/pkg/api/middlewares"
@@ -19,7 +19,7 @@ import (
 	"github.com/Roll-Play/togglelabs/pkg/logger"
 	organizationmodel "github.com/Roll-Play/togglelabs/pkg/models/organization"
 	usermodel "github.com/Roll-Play/togglelabs/pkg/models/user"
-	api_utils "github.com/Roll-Play/togglelabs/pkg/utils/api_utils"
+	apiutils "github.com/Roll-Play/togglelabs/pkg/utils/api_utils"
 	testutils "github.com/Roll-Play/togglelabs/pkg/utils/test_utils"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
@@ -85,7 +85,7 @@ func (suite *UserHandlerTestSuite) TestUserGetHandlerSuccess() {
 			organizationmodel.Admin,
 		)}, suite.db)
 
-	token, err := api_utils.CreateJWT(user.ID, time.Second*120)
+	token, err := apiutils.CreateJWT(user.ID, time.Second*120)
 	assert.NoError(t, err)
 
 	request := httptest.NewRequest(http.MethodGet, "/user", nil)
@@ -94,13 +94,24 @@ func (suite *UserHandlerTestSuite) TestUserGetHandlerSuccess() {
 	recorder := httptest.NewRecorder()
 
 	suite.Server.ServeHTTP(recorder, request)
-	response := new(handlers.UserGetResponse)
+	response := new(usermodel.UserWithOrganization)
 
 	assert.Equal(t, http.StatusOK, recorder.Code)
 	assert.NoError(t, json.Unmarshal(recorder.Body.Bytes(), response))
-	assert.Equal(t, handlers.NewUserGetResponse(user, []organizationmodel.OrganizationRecord{
-		*organization,
-	}), response)
+	expected := &usermodel.UserWithOrganization{
+		ID:        user.ID,
+		SsoID:     user.SsoID,
+		Email:     user.Email,
+		FirstName: user.FirstName,
+		LastName:  user.LastName,
+		Organizations: []usermodel.UserOrganization{
+			{
+				ID:   organization.ID,
+				Name: organization.Name,
+			},
+		},
+	}
+	assert.Equal(t, expected, response)
 }
 
 func (suite *UserHandlerTestSuite) TestUserPatchHandlerSuccess() {
@@ -117,7 +128,7 @@ func (suite *UserHandlerTestSuite) TestUserPatchHandlerSuccess() {
 	requestBody, err := json.Marshal(patchInfo)
 	assert.NoError(t, err)
 
-	token, err := api_utils.CreateJWT(user.ID, time.Second*120)
+	token, err := apiutils.CreateJWT(user.ID, time.Second*120)
 
 	assert.NoError(t, err)
 
@@ -134,6 +145,7 @@ func (suite *UserHandlerTestSuite) TestUserPatchHandlerSuccess() {
 
 	assert.Equal(t, http.StatusOK, recorder.Code)
 	assert.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+	assert.NotEqual(t, user.UpdatedAt, ur.UpdatedAt)
 	assert.Equal(t, ur.Email, response.Email)
 	assert.Equal(t, ur.FirstName, response.FirstName)
 	assert.Equal(t, ur.LastName, response.LastName)
@@ -148,7 +160,7 @@ func (suite *UserHandlerTestSuite) TestUserPatchHandlerNotFound() {
 	requestBody, err := json.Marshal(patchInfo)
 	assert.NoError(t, err)
 
-	token, err := api_utils.CreateJWT(primitive.NewObjectID(), time.Second*120)
+	token, err := apiutils.CreateJWT(primitive.NewObjectID(), time.Second*120)
 	assert.NoError(t, err)
 
 	request := httptest.NewRequest(http.MethodPatch, "/user", bytes.NewBuffer(requestBody))
@@ -157,13 +169,13 @@ func (suite *UserHandlerTestSuite) TestUserPatchHandlerNotFound() {
 	recorder := httptest.NewRecorder()
 
 	suite.Server.ServeHTTP(recorder, request)
-	var response api_errors.Error
+	var response apierrors.Error
 
 	assert.Equal(t, http.StatusNotFound, recorder.Code)
 	assert.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
-	assert.Equal(t, api_errors.Error{
+	assert.Equal(t, apierrors.Error{
 		Error:   http.StatusText(http.StatusNotFound),
-		Message: api_errors.NotFoundError,
+		Message: apierrors.NotFoundError,
 	}, response)
 }
 
@@ -180,7 +192,7 @@ func (suite *UserHandlerTestSuite) TestUserPatchHandlerOnlyChangesAllowedFields(
 			"email": "new@email.mail"
 		}`)
 
-	token, err := api_utils.CreateJWT(user.ID, time.Second*120)
+	token, err := apiutils.CreateJWT(user.ID, time.Second*120)
 	assert.NoError(t, err)
 	request := httptest.NewRequest(http.MethodPatch, "/user", bytes.NewBuffer(requestBody))
 	request.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)

--- a/pkg/api/middlewares/organization_middleware.go
+++ b/pkg/api/middlewares/organization_middleware.go
@@ -3,7 +3,7 @@ package middlewares
 import (
 	"net/http"
 
-	api_errors "github.com/Roll-Play/togglelabs/pkg/api/error"
+	apierrors "github.com/Roll-Play/togglelabs/pkg/api/error"
 	"github.com/Roll-Play/togglelabs/pkg/logger"
 	"github.com/labstack/echo/v4"
 	"go.mongodb.org/mongo-driver/bson/primitive"
@@ -19,21 +19,21 @@ func OrganizationMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 
 		if organizationHeader == "" {
 			logger.Debug("Missing organization header")
-			return api_errors.CustomError(
+			return apierrors.CustomError(
 				c,
 				http.StatusBadRequest,
-				api_errors.BadRequestError,
+				apierrors.BadRequestError,
 			)
 		}
 
 		organizationID, err := primitive.ObjectIDFromHex(organizationHeader)
 		if err != nil {
 			logger.Debug("Client error",
-				zap.String("cause", err.Error()))
-			return api_errors.CustomError(
+				zap.Error(err))
+			return apierrors.CustomError(
 				c,
 				http.StatusBadRequest,
-				api_errors.BadRequestError,
+				apierrors.BadRequestError,
 			)
 		}
 

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -6,7 +6,7 @@ import (
 	"github.com/Roll-Play/togglelabs/pkg/api/handlers"
 	"github.com/Roll-Play/togglelabs/pkg/api/middlewares"
 	"github.com/Roll-Play/togglelabs/pkg/storage"
-	api_utils "github.com/Roll-Play/togglelabs/pkg/utils/api_utils"
+	apiutils "github.com/Roll-Play/togglelabs/pkg/utils/api_utils"
 	"github.com/labstack/echo/v4"
 	"go.uber.org/zap"
 	"golang.org/x/oauth2"
@@ -63,8 +63,8 @@ func registerRoutes(app *App) {
 		app.storage.DB(),
 		oauthConfig,
 		app.logger,
-		&api_utils.HTTPClient{},
-		api_utils.NewOAuthClient(oauthConfig),
+		&apiutils.HTTPClient{},
+		apiutils.NewOAuthClient(oauthConfig),
 	)
 	app.server.POST("/oauth", ssoHandler.SignIn)
 	app.server.GET("/callback", ssoHandler.Callback)
@@ -101,4 +101,5 @@ func registerRoutes(app *App) {
 		"/:featureFlagID/toggle",
 		featureFlagHandler.ToggleFeatureFlag,
 	)
+	featureGroup.PATCH("/:featureFlagID/tags", featureFlagHandler.PatchFeatureFlagTags)
 }

--- a/pkg/models/common.go
+++ b/pkg/models/common.go
@@ -1,4 +1,4 @@
-package storage
+package models
 
 import "go.mongodb.org/mongo-driver/bson/primitive"
 

--- a/pkg/models/organization/model.go
+++ b/pkg/models/organization/model.go
@@ -145,6 +145,7 @@ func NewOrganizationRecord(name string, members []OrganizationMember) *Organizat
 		Name:     name,
 		Members:  members,
 		Projects: []Project{},
+		Tags:     []string{},
 		Timestamps: models.Timestamps{
 			CreatedAt: primitive.NewDateTimeFromTime(time.Now().UTC()),
 			UpdatedAt: primitive.NewDateTimeFromTime(time.Now().UTC()),

--- a/pkg/models/timeline/model.go
+++ b/pkg/models/timeline/model.go
@@ -42,7 +42,7 @@ type TimelineEntry struct {
 type TimelineRecord struct {
 	ID            primitive.ObjectID `json:"_id" bson:"_id"`
 	FeatureFlagID primitive.ObjectID `json:"feature_flag_id" bson:"feature_flag_id"`
-	Entries       []TimelineEntry
+	Entries       []TimelineEntry    `json:"entries" bson:"entries"`
 }
 
 func NewTimelineEntry(userID primitive.ObjectID, action string) *TimelineEntry {

--- a/pkg/models/user/model.go
+++ b/pkg/models/user/model.go
@@ -115,16 +115,15 @@ func (um *UserModel) InsertOne(ctx context.Context, record *UserRecord) (primiti
 func (um *UserModel) UpdateOne(
 	ctx context.Context,
 	id primitive.ObjectID,
-	updateValues bson.D,
+	update bson.D,
 ) error {
 	filter := bson.D{{Key: "_id", Value: id}}
-	updateValues = append(updateValues, bson.E{
+	update = append(update, bson.E{
 		Key:   "timestamps.updated_at",
 		Value: primitive.NewDateTimeFromTime(time.Now().UTC()),
 	})
-	update := bson.D{{Key: "$set", Value: updateValues}}
 
-	_, err := um.collection.UpdateOne(ctx, filter, update)
+	_, err := um.collection.UpdateOne(ctx, filter, bson.D{{Key: "$set", Value: update}})
 	if err != nil {
 		return err
 	}

--- a/pkg/utils/api_utils/api_utils.go
+++ b/pkg/utils/api_utils/api_utils.go
@@ -20,7 +20,7 @@ type BaseHTTPClient interface {
 type HTTPClient struct{}
 
 func (c *HTTPClient) Get(url string) (*http.Response, error) {
-	return http.Get(url)
+	return http.Get(url) //nolint
 }
 
 type OAuthClient interface {

--- a/pkg/utils/api_utils/api_utils.go
+++ b/pkg/utils/api_utils/api_utils.go
@@ -1,4 +1,4 @@
-package api_utils
+package apiutils
 
 import (
 	"context"
@@ -20,7 +20,7 @@ type BaseHTTPClient interface {
 type HTTPClient struct{}
 
 func (c *HTTPClient) Get(url string) (*http.Response, error) {
-	return http.Get(url) //nolint
+	return http.Get(url)
 }
 
 type OAuthClient interface {

--- a/pkg/utils/api_utils/jwt.go
+++ b/pkg/utils/api_utils/jwt.go
@@ -1,4 +1,4 @@
-package api_utils
+package apiutils
 
 import (
 	"os"


### PR DESCRIPTION
This PR adds an endpoint to add tags to a feature flag as well as the ability to pass tags when creating a feature flag.

Each feature flag has a tags set that is duplicated to the organization so we can have autocomplete in the frontend without requesting another resource